### PR TITLE
Preserve editor changes across reruns

### DIFF
--- a/core/simulador.py
+++ b/core/simulador.py
@@ -321,8 +321,12 @@ class SimuladorSobel:
         """Processa a edição de dados e cálculo de resultados"""
         # Determinar DataFrame para edição
         df_atual = self.state.get_simulacao('df_atual')
+        df_edicao_temp = self.state.get_simulacao('df_edicao_temp')
+
         if df_atual is not None:
             df_para_edicao = df_atual.copy()
+        elif df_edicao_temp is not None:
+            df_para_edicao = df_edicao_temp.copy()
         else:
             df_para_edicao = df_base.copy()
         


### PR DESCRIPTION
## Summary
- keep temporary edited DataFrame in session state
- use `df_edicao_temp` whenever `df_atual` is not available

## Testing
- `python main_teste.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6878f4d53d64832cbacd449f745bc4f5