### PR TITLE
Add pallet logistic calculations

### DIFF
--- a/core/simulador.py
+++ b/core/simulador.py
@@ -14,6 +14,7 @@ from .state_manager import StateManager
 from services.database_service import DatabaseService
 from services.geolocation_service import GeolocationService
 from services.calculation_service import CalculadoraResultados, CalculadoraPontoEquilibrio
+from services.logistics_service import LogisticsService
 from config.tributaria import ConfiguracaoTributaria
 from ui.layout import SimuladorLayout
 from utils.frete_utils import (
@@ -54,6 +55,7 @@ class SimuladorSobel:
         if self.df_logistica.empty:
             self.df_logistica = pd.DataFrame()
             st.info("ℹ️ Dados logísticos não encontrados ou vazios.")
+        self.logistics_service = None if self.df_logistica.empty else LogisticsService(self.df_logistica)
         
         # Serviço de geolocalização
         api_key = os.getenv("GOOGLE_MAPS_API_KEY")
@@ -514,7 +516,12 @@ class SimuladorSobel:
         
         # Exibir resumo executivo
         self.layout.exibir_resumo_executivo(df_display)
-        
+
+        # Resumo logístico se dados disponíveis
+        if self.logistics_service:
+            info_log = self.logistics_service.calcular_logistica(df_final)
+            self.layout.exibir_resumo_logistico(info_log)
+
         # Exibir detalhamento do cálculo
         self.layout.exibir_detalhamento_calculo(df_final, resultados)
         

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -145,7 +145,15 @@ class DatabaseService:
         try:
             with pyodbc.connect(_self.connection_string) as conexao:
                 query = "SELECT * FROM BISOBEL.dbo.PRODUTOS_TRUCK_CARRETA"
-                return pd.read_sql(query, conexao)
+                df = pd.read_sql(query, conexao)
+                df.columns = df.columns.str.strip()
+
+                # Normalizar campos importantes
+                for col in ["CXS_PLT", "PESO", "PESO_KG", "VOLUME", "VOLUME_M3"]:
+                    if col in df.columns:
+                        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+                return df
         except Exception as e:
             st_error(f"Erro ao carregar dados logísticos: {e}")
             return pd.DataFrame()

--- a/services/logistics_service.py
+++ b/services/logistics_service.py
@@ -1,0 +1,82 @@
+import math
+import pandas as pd
+
+
+class LogisticsService:
+    """Realiza cálculos logísticos de pallets e veículos"""
+
+    PALLET_TRUCK = 29
+    PALLET_CARRETA = 58
+    PESO_TRUCK = 12000  # kg
+    PESO_CARRETA = 28000  # kg
+
+    def __init__(self, df_logistica: pd.DataFrame):
+        self.df_logistica = df_logistica if df_logistica is not None else pd.DataFrame()
+        self.codigo_col = next((c for c in ['CODIGO', 'Codigo', 'PRODUTO', 'SKU'] if c in self.df_logistica.columns), None)
+        self.pallet_col = next((c for c in ['CXS_PLT', 'CX_PALLET', 'CAIXAS_PALLET'] if c in self.df_logistica.columns), None)
+        self.peso_col = next((c for c in ['PESO', 'PESO_KG'] if c in self.df_logistica.columns), None)
+        self.volume_col = next((c for c in ['VOLUME', 'VOLUME_M3', 'CUBAGEM'] if c in self.df_logistica.columns), None)
+
+    def calcular_logistica(self, df_produtos: pd.DataFrame) -> dict:
+        """Calcula pallets fechados e veículos necessários"""
+        if self.df_logistica.empty or not self.codigo_col or not self.pallet_col:
+            return {
+                'peso_total': 0.0,
+                'truck_qtd': 0,
+                'carreta_qtd': 0,
+                'sugestoes': [],
+                'detalhes': pd.DataFrame()
+            }
+
+        codigo_prod = next((c for c in ['CODIGO', 'Codigo', 'SKU', 'Produto', 'Descrição', 'DESCRICAO'] if c in df_produtos.columns), None)
+        if not codigo_prod or 'Quantidade' not in df_produtos.columns:
+            return {
+                'peso_total': 0.0,
+                'truck_qtd': 0,
+                'carreta_qtd': 0,
+                'sugestoes': [],
+                'detalhes': pd.DataFrame()
+            }
+
+        df_merge = df_produtos[[codigo_prod, 'Quantidade']].merge(
+            self.df_logistica,
+            left_on=codigo_prod,
+            right_on=self.codigo_col,
+            how='left'
+        )
+
+        df_merge[self.pallet_col] = pd.to_numeric(df_merge[self.pallet_col], errors='coerce').fillna(1)
+        if self.peso_col:
+            df_merge[self.peso_col] = pd.to_numeric(df_merge[self.peso_col], errors='coerce').fillna(0)
+        if self.volume_col:
+            df_merge[self.volume_col] = pd.to_numeric(df_merge[self.volume_col], errors='coerce').fillna(0)
+
+        df_merge['pallets_fechados'] = (df_merge['Quantidade'] // df_merge[self.pallet_col]).astype(int)
+        df_merge['resto_caixas'] = (df_merge['Quantidade'] % df_merge[self.pallet_col]).astype(int)
+        df_merge['peso_total'] = df_merge['Quantidade'] * (df_merge[self.peso_col] if self.peso_col else 0)
+        df_merge['volume_total'] = df_merge['Quantidade'] * (df_merge[self.volume_col] if self.volume_col else 0)
+
+        total_pallets = (df_merge['pallets_fechados'] + (df_merge['resto_caixas'] > 0).astype(int)).sum()
+        total_peso = df_merge['peso_total'].sum()
+
+        trucks_pallet = math.ceil(total_pallets / self.PALLET_TRUCK) if total_pallets > 0 else 0
+        trucks_peso = math.ceil(total_peso / self.PESO_TRUCK) if total_peso > 0 else 0
+        trucks = max(trucks_pallet, trucks_peso)
+
+        carretas_pallet = math.ceil(total_pallets / self.PALLET_CARRETA) if total_pallets > 0 else 0
+        carretas_peso = math.ceil(total_peso / self.PESO_CARRETA) if total_peso > 0 else 0
+        carretas = max(carretas_pallet, carretas_peso)
+
+        sugestoes = []
+        for _, row in df_merge.iterrows():
+            if row['resto_caixas'] > 0:
+                faltam = int(row[self.pallet_col] - row['resto_caixas'])
+                sugestoes.append({'produto': row[codigo_prod], 'quantidade': faltam})
+
+        return {
+            'peso_total': float(total_peso),
+            'truck_qtd': int(trucks),
+            'carreta_qtd': int(carretas),
+            'sugestoes': sugestoes,
+            'detalhes': df_merge
+        }

--- a/tests/test_pallet_service.py
+++ b/tests/test_pallet_service.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from services.logistics_service import LogisticsService
+
+def test_calculo_pallets_e_sugestoes():
+    log_df = pd.DataFrame({
+        'CODIGO': ['A', 'B'],
+        'CXS_PLT': [50, 40],
+        'PESO_KG': [10, 8],
+        'VOLUME_M3': [0.1, 0.08]
+    })
+    prod_df = pd.DataFrame({
+        'CODIGO': ['A', 'B'],
+        'Quantidade': [75, 80]
+    })
+    service = LogisticsService(log_df)
+    info = service.calcular_logistica(prod_df)
+    detalhes = info['detalhes']
+    a = detalhes[detalhes['CODIGO'] == 'A'].iloc[0]
+    assert a['pallets_fechados'] == 1
+    assert a['resto_caixas'] == 25
+    assert info['truck_qtd'] >= 1
+    assert any(s['produto'] == 'A' and s['quantidade'] == 25 for s in info['sugestoes'])

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -564,6 +564,23 @@ class SimuladorLayout:
     def exibir_resumo_executivo(self, df_display: pd.DataFrame):
         """Exibe resumo executivo"""
         ResumoExecutivoComponent.exibir_resumo(df_display)
+
+    def exibir_resumo_logistico(self, info: dict):
+        """Exibe resumo de peso e veículos"""
+        if not info:
+            return
+        st.markdown("### 🚚 Resumo Logístico")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            st.metric("Peso Total", f"{info['peso_total']:.1f} kg")
+        with col2:
+            st.metric("Trucks", info['truck_qtd'])
+        with col3:
+            st.metric("Carretas", info['carreta_qtd'])
+        if info.get('sugestoes'):
+            st.markdown("#### 📦 Sugestões para Completar Pallets")
+            for s in info['sugestoes']:
+                st.write(f"{s['produto']}: +{s['quantidade']} un.")
     
     def exibir_detalhamento_calculo(self, df_final: pd.DataFrame, resultados: pd.DataFrame):
         """Exibe detalhamento do cálculo do primeiro produto"""


### PR DESCRIPTION
## Summary
- extend database service to parse pallet logistic fields
- add a new `LogisticsService` to compute pallet usage
- display pallet summary in the Streamlit UI
- write unit tests for logistic calculations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879401c0db4832c8b82efae84ddcf33